### PR TITLE
Update readme link to HELICS GitHub repository

### DIFF
--- a/Formula/helics.rb
+++ b/Formula/helics.rb
@@ -1,9 +1,9 @@
 class Helics < Formula
   desc "Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS)"
-  homepage "https://github.com/GMLC-TDC/HELICS-src"
-  url "https://github.com/GMLC-TDC/HELICS-src/archive/v2.0.0.tar.gz"
+  homepage "https://github.com/GMLC-TDC/HELICS"
+  url "https://github.com/GMLC-TDC/HELICS/archive/v2.0.0.tar.gz"
   sha256 "aa1a7be9032d1e7ad886bced08b4e0e8d3ffaf13fa21d1239e91c47e8a9dd677"
-  head "https://github.com/GMLC-TDC/HELICS-src.git", :branch => "develop"
+  head "https://github.com/GMLC-TDC/HELICS.git", :branch => "develop"
 
   bottle do
     cellar :any

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/GMLC-TDC/homebrew-helics.svg?branch=master)](https://travis-ci.org/GMLC-TDC/homebrew-helics)
 
-The formulae provided in this tap are specific to HELICS. Please see [HELICS-src](https://github.com/GMLC-TDC/HELICS-src) for more information.
+The formulae provided in this tap are specific to HELICS. Please see [HELICS](https://github.com/GMLC-TDC/HELICS) for more information.
 
 ## Install
 


### PR DESCRIPTION
Update on June 19, 2019 after the HELICS-src to HELICS GitHub repository rename.