### PR TITLE
Update brew package to HELICS 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,21 @@ install:
   - mkdir -p $(brew --repo)/Library/Taps/GMLC-TDC
   - ln -s $PWD $(brew --repo)/Library/Taps/GMLC-TDC/homebrew-helics
   - brew tap --repair
+  
 env:
-  - PACKAGE=helics
+  global:
+    - PACKAGE=helics
+
+jobs:
+  include:
+    - env: VERSION="--HEAD"
+    # Make sure the stable version builds for formula updates getting merged to master
+    - if: branch = master
+      env: VERSION=""
+      
 script:
   - brew tap GMLC-TDC/helics
-  - brew install -v $PACKAGE --HEAD
+  - brew install -v $PACKAGE $VERSION
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: xcode10.2
 before_install:
   - brew update
 install:

--- a/Formula/helics.rb
+++ b/Formula/helics.rb
@@ -1,8 +1,7 @@
 class Helics < Formula
   desc "Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS)"
   homepage "https://github.com/GMLC-TDC/HELICS"
-  url "https://github.com/GMLC-TDC/HELICS.git", :using => :git, :tag => "v2.1.0"
-  sha256 "73e24a09d59ae201e750ac287ab5ceb52c275e4ba6077d47274a9fafc612f2b5"
+  url "https://github.com/GMLC-TDC/HELICS.git", :using => :git, :tag => "v2.1.1"
   head "https://github.com/GMLC-TDC/HELICS.git", :branch => "develop"
 
   bottle do

--- a/Formula/helics.rb
+++ b/Formula/helics.rb
@@ -1,7 +1,7 @@
 class Helics < Formula
   desc "Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS)"
   homepage "https://github.com/GMLC-TDC/HELICS"
-  url "https://github.com/GMLC-TDC/HELICS/archive/v2.0.0.tar.gz"
+  url "https://github.com/GMLC-TDC/HELICS.git", :using => "git", :tag => "v2.1.0"
   sha256 "73e24a09d59ae201e750ac287ab5ceb52c275e4ba6077d47274a9fafc612f2b5"
   head "https://github.com/GMLC-TDC/HELICS.git", :branch => "develop"
 

--- a/Formula/helics.rb
+++ b/Formula/helics.rb
@@ -1,7 +1,7 @@
 class Helics < Formula
   desc "Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS)"
   homepage "https://github.com/GMLC-TDC/HELICS"
-  url "https://github.com/GMLC-TDC/HELICS.git", :using => "git", :tag => "v2.1.0"
+  url "https://github.com/GMLC-TDC/HELICS.git", :using => :git, :tag => "v2.1.0"
   sha256 "73e24a09d59ae201e750ac287ab5ceb52c275e4ba6077d47274a9fafc612f2b5"
   head "https://github.com/GMLC-TDC/HELICS.git", :branch => "develop"
 


### PR DESCRIPTION
- Update HELICS package stable version to 2.1.1 and use git (for submodule support)
- Add a test for the stable HELICS brew package for merges/commits to master